### PR TITLE
Fix profile command examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,9 +51,9 @@ The ZI command executed will be equivalent to:
 
 ```zsh
 zi lucid reset \
- atclone"[[ -z ${commands[dircolors]} ]] && local P=g
-    \${P}sed -i '/DIR/c\DIR 38;5;63;1' LS_COLORS; \
-    \${P}dircolors -b LS_COLORS > clrs.zsh" \
+ atclone"[[ -z \${commands[dircolors]} ]] && local P=g
+    \${P}sed -i '/DIR/c\DIR 38;5;63;1' LS_COLORS
+    \${P}dircolors -b LS_COLORS >! clrs.zsh" \
  atpull'%atclone' pick"clrs.zsh" nocompile'!' \
  atload'zstyle ":completion:*:default" list-colors "${(s.:.)LS_COLORS}";' for \
     trapd00r/LS_COLORS
@@ -68,9 +68,9 @@ The ZI command executed will be equivalent to:
 
 ```zsh
 zi lucid reset \
- atclone"[[ -z ${commands[dircolors]} ]] && local P=g
-    \${P}sed -i '/DIR/c\DIR 38;5;63;1' LS_COLORS; \
-    \${P}dircolors -b LS_COLORS > clrs.zsh" \
+ atclone"[[ -z \${commands[dircolors]} ]] && local P=g
+    \${P}sed -i '/DIR/c\DIR 38;5;63;1' LS_COLORS
+    \${P}dircolors -b LS_COLORS >! clrs.zsh" \
  atpull'%atclone' pick"clrs.zsh" nocompile'!' for \
     trapd00r/LS_COLORS
 ```
@@ -86,8 +86,8 @@ The ZI command executed will be equivalent to:
 
 ```zsh
 zi lucid \
- atclone"[[ -z ${commands[dircolors]} ]] && local P=g
-     ${P}dircolors -b LS_COLORS > clrs.zsh" \
+ atclone"[[ -z \${commands[dircolors]} ]] && local P=g
+     \${P}dircolors -b LS_COLORS >! clrs.zsh" \
  atpull'%atclone' pick"clrs.zsh" nocompile'!' \
  atload'zstyle ":completion:*:default" list-colors "${(s.:.)LS_COLORS}";' for \
     trapd00r/LS_COLORS


### PR DESCRIPTION
I wanted to issue the command directly rather than use the package, and the README here provides some excellent examples. They did not however work for me.

- MacOS 11.6.5 (Big Sur)
- zsh 5.8
- z-shell 1.0.0

Seems that `${commands[dircolors]}` in `atclone` is being run in the scope of the calling _.zshrc_ rather than inside the eval, so it just ends up putting nothing into the test which then fails because somehow that's different than a variable that resolves to empty.

```
❯ zi lucid reset \
 atclone"[[ -z ${commands[dircolors]} ]] && local P=g
    \${P}sed -i '/DIR/c\DIR 38;5;63;1' LS_COLORS; \
    \${P}dircolors -b LS_COLORS > clrs.zsh" \
 atpull'%atclone' pick"clrs.zsh" nocompile'!' \
 atload'zstyle ":completion:*:default" list-colors "${(s.:.)LS_COLORS}";' for \
    trapd00r/LS_COLORS

Downloading trapd00r/LS_COLORS…

Cloning into '/Users/USERNAME/.config/zsh/.zi/plugins/trapd00r---LS_COLORS'...
▋ ███████████ OBJ: 100, PACK: 1242/1242, COMPR: 100%, REC: 100%, RES: 100%
(eval):1: unknown condition: -z
No files for compilation found (pick-ice didn't match).
```

The solution was just to escape the `$` at the front of the test. I made a few other minor changes as well.

- Escaped all `$` characters.
- Removed `; \` which wasn't required, and wasn't used with line 2.
- Added force clobber to the redirect into `clrs.zsh` as is done inside the package.